### PR TITLE
fix the incorrect list of ends for _cat_ranges

### DIFF
--- a/fsspec/asyn.py
+++ b/fsspec/asyn.py
@@ -476,7 +476,7 @@ class AsyncFileSystem(AbstractFileSystem):
         if not isinstance(starts, Iterable):
             starts = [starts] * len(paths)
         if not isinstance(ends, Iterable):
-            ends = [starts] * len(paths)
+            ends = [ends] * len(paths)
         if len(starts) != len(paths) or len(ends) != len(paths):
             raise ValueError
         coros = [


### PR DESCRIPTION
I think the list of "ends" should come from the argument "ends" if it is not iterable for the function "_cat_ranges".